### PR TITLE
Use JSON payload to provide additional document info

### DIFF
--- a/pyjsonnlp/microservices/flask_server.py
+++ b/pyjsonnlp/microservices/flask_server.py
@@ -81,6 +81,10 @@ class FlaskMicroservice(Microservice, Flask):
         args = dict((k, map_value(k, v)) for k, v in request.args.items())
         for k, v in request.form.items():
             args[k] = map_value(k, v)
+        if request.is_json:
+            data = request.get_json()
+            for k, v in data.items():
+                args[k] = map_value(k, v)
 
         return args
 


### PR DESCRIPTION
I would like to be able to set DC.meta of a new JSON-NLP document using the JSON payload. 
Currently only the "text" field from a JSON payload is available for pipeline process method.